### PR TITLE
Reduce scrollbars

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -1,5 +1,5 @@
 .control-button {
-  position: absolute;
+  position: fixed;
   font-size: 2rem;
 }
 .control-button:hover {
@@ -15,7 +15,7 @@
   right: 10px;
 }
 .current-page-index {
-  position: absolute;
+  position: fixed;
   font-size: 0.8rem;
   color: #222;
   bottom: 10px;

--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -2,15 +2,15 @@
   <div id="editor">
     <div class="editor" :style="{ display: showEditor }"></div>
     <div :id="selectedMdTheme" class="preview" :class="selectedMode">
-      <div style="position: relative; overflow: scroll; height: 100%;">
-        <div class="markdown-body" v-html="parsed" style="box-sizing: border-box; overflow: scroll; height: 100%;"></div>
+      <div class="slide-controls">
+        <div class="markdown-body" v-html="parsed"></div>
         <div class="control-button control-left"  @click="moveSlide(showIndex--)" v-if="selectedMode.indexOf('slide') === 0">&#10094;</div>
         <div class="control-button control-right" @click="moveSlide(showIndex++)" v-if="selectedMode.indexOf('slide') === 0">&#10095;</div>
         <div class="current-page-index" v-if="selectedMode.indexOf('slide') === 0">{{ `${showIndex+1} / ${maxIndex}`  }}</div>
         <div class="control-button control-fullscreen" @click="handleFullscreen">fullscreen</div>
       </div>
       <div v-if="showTextLint" class="textlint">
-        <div style="position: fixed; width: 200px; background: #9fb4be; color: #263238; padding: 5px;">
+        <div class="textlint-controls">
           <div style="position: relative;">
             <img width="25" src="https://textlint.github.io/img/textlint-icon_256x256.png"></img>
             <span class="textlint-header-button" style="left: 50px; color: #9be304;" @click="fixByTextLint">✔ Fix</span>
@@ -400,14 +400,13 @@ html, body, #editor, #app {
 }
 .editor {
   flex: 1;
-  overflow: scroll;
 }
 .preview {
   flex: 1;
   display: flex;
   flex-flow: column;
   justify-content: space-between;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 .CodeMirror {
   font-size: 1rem;
@@ -443,7 +442,7 @@ html, body, #editor, #app {
   min-height: 300px;
   background: #263238;
   color: #9fb4be;
-  overflow: scroll;
+  overflow: scroll;  
   position: relative;
 }
 .textlint table {
@@ -471,5 +470,20 @@ html, body, #editor, #app {
 }
 .textlint-header-button:hover {
   background: #3e515b;
+}
+.slide-controls {
+  position: relative;
+  height: 100%;
+}
+.markdown-body {
+  box-sizing: border-box;
+  height: 100%;
+}
+.textlint-controls {
+  position: fixed;
+  width: 200px;
+  background: #9fb4be;
+  color: #263238;
+  padding: 5px;
 }
 </style>


### PR DESCRIPTION
日本語にて失礼します。
スクロールバーの量を減らせそうなので、ちょっとやってみました。
下記は修正前

![image](https://user-images.githubusercontent.com/3132889/33726184-aad91e36-dbb7-11e7-923e-541a1ec1a7b7.png)

修正後（normal）

![image](https://user-images.githubusercontent.com/3132889/33726301-f47f9c9a-dbb7-11e7-85af-fb93faa31b89.png)

修正後（slide）

![image](https://user-images.githubusercontent.com/3132889/33726361-2675b1c6-dbb8-11e7-9cdb-ff494458b67c.png)

修正後（slide-center）…上がはみ出てしまう問題がありましたが、修正はしていません

![image](https://user-images.githubusercontent.com/3132889/33726406-4750ffa4-dbb8-11e7-81e6-ab361509a582.png)

コンテンツが短い場合

![image](https://user-images.githubusercontent.com/3132889/33726560-b9ae1b90-dbb8-11e7-8e28-b60e2bd20c67.png)

- コンテンツの縦が短い場合でもスクロールバー出しっぱなしにしています（スクロールバーの有無でコンテンツが左右にがたつくのを防ぐ意図だと思ったので）
- textlint-uiがありそうでしたが、出す方法がわからなかったために調整後未確認です。
- 横スクロールバーは外してしまいましたが、コンテンツが横にはみ出すケースが考えられる場合は教えてください
